### PR TITLE
39031: Update GlueDB to use new edi_codec version from Altus FEIN Revert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'bh'
 gem 'nokogiri-happymapper', :require => 'happymapper'
 gem 'prawn', '~> 0.11.1'
 gem 'forkr', '1.0.2'
-gem 'edi_codec', git: "git@github.com:health-connector/edi_codec.git", tag: "ma-0.2.1"
+gem 'edi_codec', git: "git@github.com:health-connector/edi_codec.git", tag: "ma-0.2.2"
 gem 'ibsciss-middleware', git: "https://github.com/dchbx/ruby-middleware.git", :require => "middleware"
 gem 'rgl', '0.5.2'
 gem 'aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: git@github.com:health-connector/edi_codec.git
-  revision: 1f475ce0d0731e9557c0744457da5c68adc46221
-  tag: ma-0.2.1
+  revision: a6d0532fa76e84d6725593776768b6a9a0e58704
+  tag: ma-0.2.2
   specs:
     edi_codec (0.1.2)
       activesupport (>= 3.2)


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [39031](https://devops.dchbx.org/redmine/issues/39031) |
| App-Dev Road Map # | n/a |
| Start Date | n/a |
| Due Date | n/a  |
| App-Dev Priority | UP-Disqueued |
| Development Story Points | n/a |
| Peer Review Story Points | n/a |
| Ticket Author | @TreyE |