### PR TITLE
update gha runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/push_checks.yml
+++ b/.github/workflows/push_checks.yml
@@ -3,28 +3,36 @@ on: push
 
 jobs:
   rspec:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     steps:
-      - name: Set up Ruby 2.1.10
+      - name: Get Packages for Ruby Prerequisites
         run: |
-          sudo add-apt-repository -y ppa:brightbox/ruby-ng
           sudo apt-get -y update
-          sudo apt-get -y install ruby2.1 ruby2.1-dev ruby-switch
-          sudo apt-get -y install ruby-switch
-          sudo ruby-switch --list
-          sudo ruby-switch --set ruby2.1
+          sudo apt-get -y install git libntirpc-dev libxml2 libxml2-dev curl libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+      - name: Install libssl1.0-dev from bionic sources
+        run: |
+          echo 'deb http://security.ubuntu.com/ubuntu bionic-security main' | sudo tee -a /etc/apt/sources.list.d/bionic-security.list
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+          sudo apt update && apt-cache policy libssl1.0-dev
+          sudo apt-get -y install libssl1.0-dev
+      - name: Install Ruby
+        run: |
+          curl -O https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2
+          tar xjf ruby-2.1.10.tar.bz2
+          cd ruby-2.1.10 && ./configure && make -j 2
+          sudo make install
       - name: Launch MongoDB
         uses: wbari/start-mongoDB@v0.2
         with:
           mongoDBVersion: 3.4
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v2
         with:
           # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0, lts
           node-version: 9.11.1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache Gems
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gluedb-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -35,6 +43,7 @@ jobs:
           sudo gem install bundler -v '1.17.3'
           export BUNDLE_GITHUB__COM=${{ secrets.dchbx_deployments_token }}:x-oauth-basic
           bundle config path vendor/bundle
+          export BUNDLE_GITHUB__COM=${{ secrets.dchbx_deployments_token }}:x-oauth-basic
           bundle install
       - name: run tests
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,8 @@ end
 group :production do
   gem 'unicorn', '4.8.2'
 #  gem 'bluepill', '0.0.68'
-  gem 'eye', '0.6.4'
-  gem 'celluloid', '0.15.2'
+  gem 'eye', '0.10.0'
+  gem 'celluloid', '~> 0.17.3'
   gem 'nio4r', '1.1.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,11 +114,27 @@ GEM
       carrierwave (>= 0.8.0, < 0.11.0)
       mongoid (>= 3.0, < 5.0)
       mongoid-grid_fs (>= 1.3, < 3.0)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
-    celluloid-io (0.15.0)
-      celluloid (>= 0.15.0)
-      nio4r (>= 0.5.0)
+    celluloid (0.17.4)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-io (0.17.3)
+      celluloid (>= 0.17.2)
+      nio4r (>= 1.1)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     ci_reporter (2.0.0)
@@ -154,11 +170,11 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.7.0)
-    eye (0.6.4)
-      celluloid (~> 0.15.0)
-      celluloid-io (~> 0.15.0)
-      sigar (~> 0.7.2)
-      state_machine
+    eye (0.10.0)
+      celluloid (~> 0.17.3)
+      celluloid-io (~> 0.17.0)
+      kostya-sigar (~> 2.0.0)
+      state_machines
       thor
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -199,6 +215,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.11.0)
+    kostya-sigar (2.0.10)
     lazy_priority_queue (0.1.1)
     less (2.5.1)
       commonjs (~> 0.2.7)
@@ -373,7 +390,6 @@ GEM
       uuid (~> 2.3.7)
       wasabi (~> 3.3.0)
     sexp_processor (4.7.0)
-    sigar (0.7.3)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -386,7 +402,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    state_machine (1.2.0)
+    state_machines (0.5.0)
     stream (0.5)
     systemu (2.6.5)
     test-unit (3.2.3)
@@ -394,10 +410,10 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thor (0.20.0)
+    thor (1.2.2)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timers (1.1.0)
+    timers (4.3.5)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -440,7 +456,7 @@ DEPENDENCIES
   capistrano (= 2.15.4)
   capybara (= 2.4.4)
   carrierwave-mongoid (= 0.7.1)
-  celluloid (= 0.15.2)
+  celluloid (~> 0.17.3)
   ci_reporter (= 2.0.0)
   coffee-rails (~> 3.2.1)
   config (= 1.0.0)
@@ -448,7 +464,7 @@ DEPENDENCIES
   designmodo-flatuipro-rails!
   devise (= 3.3.0)
   edi_codec!
-  eye (= 0.6.4)
+  eye (= 0.10.0)
   factory_girl (= 4.5.0)
   factory_girl_rails (= 4.5.0)
   font-awesome-rails (= 4.2.0.0)
@@ -503,4 +519,4 @@ DEPENDENCIES
   virtus
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     bh (1.3.6)
       actionpack
       activesupport

--- a/spec/support/acapi_vocabulary_spec_helpers.rb
+++ b/spec/support/acapi_vocabulary_spec_helpers.rb
@@ -2,23 +2,24 @@ require 'open-uri'
 
 module AcapiVocabularySpecHelpers
   ACAPI_SCHEMA_FILE_LIST = %w(
-assistance.xsd
-common.xsd
-config.xsd
-dms.xsd
-document_storage.xsd
-edi.xsd
-edi_process.xsd
-individual.xsd
-links.xsd
-organization.xsd
-plan.xsd
-policy.xsd
-premium.xsd
-verification_services.xsd
-vocabulary.xsd
-verification_services.xsd
-credits.xsd
+    assistance.xsd
+    common.xsd
+    config.xsd
+    credits.xsd
+    dms.xsd
+    document_storage.xsd
+    edi.xsd
+    edi_process.xsd
+    individual.xsd
+    links.xsd
+    organization.xsd
+    paynow.xsd
+    plan.xsd
+    policy.xsd
+    premium.xsd
+    verification_services.xsd
+    vocabulary.xsd
+    verification_services.xsd    
   )
 
   def download_vocabularies

--- a/spec/support/acapi_vocabulary_spec_helpers.rb
+++ b/spec/support/acapi_vocabulary_spec_helpers.rb
@@ -33,7 +33,7 @@ verification_services.xsd
   def download_schema_file(file, s_dir)
     f_name = File.join(s_dir, file)
     unless File.exist?(f_name)
-      uri = "https://raw.githubusercontent.com/dchbx/cv/master/#{file}"
+      uri = "https://raw.githubusercontent.com/ideacrew/cv/master/#{file}"
       download = open(uri)
       IO.copy_stream(download, f_name)
     end

--- a/spec/support/acapi_vocabulary_spec_helpers.rb
+++ b/spec/support/acapi_vocabulary_spec_helpers.rb
@@ -18,6 +18,7 @@ premium.xsd
 verification_services.xsd
 vocabulary.xsd
 verification_services.xsd
+credits.xsd
   )
 
   def download_vocabularies


### PR DESCRIPTION
this PR updates ubuntu version (from 16 to 22), to be able to run the GHA, the config is based on IC repo changes

https://github.com/ideacrew/gluedb/pull/162

it also fixes a broken URL because of the DC repos were converted to private, pointed to IC version
