### PR TITLE
downgrade timers gem to allow depoly script to be executed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,7 @@ GEM
     thor (1.2.2)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timers (4.3.5)
+    timers (4.3.2)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)


### PR DESCRIPTION
Original fix for GHA included timers gem version 4.3.5 , this downgrades it a little bit to 4.3.2 to account for a syntax error