### PR TITLE
limiting nfp recon data pull to only 3 years

### DIFF
--- a/script/queries/nfp_audit_report_non_congress.rb
+++ b/script/queries/nfp_audit_report_non_congress.rb
@@ -30,7 +30,7 @@ start_year = Date.today.year - 3
 pols = Policy.where({
     :enrollees => {"$elemMatch" => {
           :rel_code => "self",
-          :coverage_start => {"gt" => Date.new(start_year, 12, 31)},
+          :coverage_start => {"$gt" => Date.new(start_year, 12, 31)},
     }}, :employer_id => { "$in" => emp_ids } })
 
 Caches::MongoidCache.allocate(Plan)

--- a/script/queries/nfp_audit_report_non_congress.rb
+++ b/script/queries/nfp_audit_report_non_congress.rb
@@ -26,9 +26,11 @@ congress_feins = %w()
 
 emp_ids = Employer.where(:fein => {"$nin" => congress_feins }).map(&:id)
 
+start_year = Date.today.year - 3
 pols = Policy.where({
     :enrollees => {"$elemMatch" => {
-          :rel_code => "self"
+          :rel_code => "self",
+          :coverage_start => {"gt" => Date.new(start_year, 12, 31)},
     }}, :employer_id => { "$in" => emp_ids } })
 
 Caches::MongoidCache.allocate(Plan)


### PR DESCRIPTION
The data pull for HBX data for the NFP Recon process currently pulls for all years.  
Developers who run this must manually add this date filter to complete the report for NFP.
This change will automatically grab the past 3 years worth of data without manual change from developers.