### PR TITLE
Add additional gha workflows

### DIFF
--- a/.github/workflows/build-reports-image.yml
+++ b/.github/workflows/build-reports-image.yml
@@ -1,6 +1,7 @@
 name: Build reports image
 
 on:
+  push: #temp to register workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/build-reports-image.yml
+++ b/.github/workflows/build-reports-image.yml
@@ -1,0 +1,82 @@
+name: Build reports image
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: 'master'
+        description: 'Branch to build'
+        required: true
+      commit_sha:
+        description: 'Commit sha to build'
+        required: true
+  repository_dispatch:
+    types:
+      - build-reports-image
+
+concurrency:
+  group: reports-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      client: ${{ steps.prep.outputs.client }}
+      branch: ${{ steps.prep.outputs.branch}}
+      commit_sha: ${{ steps.prep.outputs.commit_sha }}
+    steps:
+      - name: Set variables from workflow dispatch
+        id: prep
+        run: |
+          if [[ "${{github.event_name}}" == "repository_dispatch" ]]; then 
+            echo ::set-output name=client::${{ github.event.client_payload.client }}
+            echo ::set-output name=branch::${{ github.event.client_payload.branch }}
+            echo ::set-output name=commit_sha::${{ github.event.client_payload.commit_sha }}
+          else
+            echo ::set-output name=client::${{ github.event.inputs.client }}
+            echo ::set-output name=branch::${{ github.event.inputs.branch }}
+            echo ::set-output name=commit_sha::${{ github.event.inputs.commit_sha }}       
+          fi 
+
+  build-and-upload-image:
+    runs-on: ubuntu-latest
+    needs: [prep]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prep.outputs.branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build reports Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          file: .docker/production/Dockerfile.gha
+          target: reports
+          tags: ghcr.io/health-connector/gluedb:cca-reports
+          build-args: |
+            COMMIT_SHA=${{ needs.prep.outputs.commit_sha }}
+            BRANCH=${{ needs.prep.outputs.branch }}

--- a/.github/workflows/build-reports-image.yml
+++ b/.github/workflows/build-reports-image.yml
@@ -1,7 +1,6 @@
 name: Build reports image
 
 on:
-  push: #temp to register workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/build-update-image.yml
+++ b/.github/workflows/build-update-image.yml
@@ -136,7 +136,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
           build-args: |
             HOSTNAME=172.17.0.1
-            GEM_OAUTH_TOKEN=${{ secrets.gem_oauth_token }}
+            GEM_OAUTH_TOKEN=${{ secrets.dchbx_deployments_token }}
             COMMIT_SHA=${{ needs.prep.outputs.commit_sha }}
             BRANCH=${{ needs.prep.outputs.branch }}
 

--- a/.github/workflows/build-update-image.yml
+++ b/.github/workflows/build-update-image.yml
@@ -3,7 +3,6 @@ name: Build Update Image
 run-name: Build Update Image 
 
 on:
-  push: #temp to register workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/build-update-image.yml
+++ b/.github/workflows/build-update-image.yml
@@ -1,0 +1,160 @@
+name: Build Update Image
+
+run-name: Build Update Image 
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: "master"
+        description: "Branch to build"
+        required: true
+      commit_sha:
+        description: "Commit sha to build"
+        required: true
+
+  repository_dispatch:
+    types:
+      - build-update-image
+
+concurrency:
+  group: update-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RABBITMQ_DEFAULT_USER: "guest"
+  RABBITMQ_DEFAULT_PASS: "guest"
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      tagged_image: ${{ steps.prep.outputs.tagged_image }}
+      tagged_images: ${{ steps.prep.outputs.tagged_images }}
+      branch: ${{ steps.prep.outputs.branch }}
+      commit_sha: ${{ steps.prep.outputs.commit_sha }}
+      repository_name: gluedb
+    steps:
+      - name: Set variables from workflow dispatch
+        id: prep
+        run: |
+          repo="ghcr.io/health-connector/gluedb"
+          if [[ "${{github.event_name}}" == "repository_dispatch" ]]; then 
+            echo ::set-output name=client::${{ github.event.client_payload.client }}
+            echo ::set-output name=branch::${{ github.event.client_payload.branch }}
+            echo ::set-output name=commit_sha::${{ github.event.client_payload.commit_sha }}
+            echo ::set-output name=tagged_image::${repo}:${{ github.event.client_payload.branch }}-${{ github.event.client_payload.commit_sha }}-glue-update
+            echo ::set-output name=tagged_images::${repo}:${{ github.event.client_payload.branch }}-${{ github.event.client_payload.commit_sha }}-glue-update,${repo}:latest-prod-glue-update-${{ github.event.client_payload.client }}
+          else
+            echo ::set-output name=client::${{ github.event.inputs.client }}
+            echo ::set-output name=branch::${{ github.event.inputs.branch }}
+            echo ::set-output name=commit_sha::${{ github.event.inputs.commit_sha }}       
+            echo ::set-output name=tagged_image::${repo}:${{ github.event.inputs.branch }}-${{ github.event.inputs.commit_sha }}-glue-update
+            echo ::set-output name=tagged_images::${repo}:${{ github.event.inputs.branch }}-${{ github.event.inputs.commit_sha }}-glue-update
+          fi 
+
+  # Uses buildx to build and push the image
+  build-and-upload-image:
+    needs: [prep]
+    runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+          - 15672:15672
+        options: >-
+          --name "rabbitmq"
+          --health-cmd "rabbitmqctl node_health_check"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mongo:
+        image: mongo:4.2
+        ports:
+          - 27017:27017
+        options: >-
+          --name "mongo"
+          --health-cmd mongo
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prep.outputs.branch }}
+
+      - name: Add git HEAD info to docker image
+        run: git show --quiet HEAD > release.txt
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      # Add vhosts to RabbitMQ
+      - run: |
+          docker exec rabbitmq rabbitmqctl add_vhost /
+          docker exec rabbitmq rabbitmqctl add_vhost event_source
+          docker exec rabbitmq rabbitmqctl set_permissions -p event_source guest ".*" ".*" ".*"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Glue Update Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: .docker/production/Dockerfile.gha
+          # Set the desired build target here
+          target: update
+          # needed to access mongo and rabbit on GHA machine
+          network: host
+          # send to public registry if not a pull request
+          push: ${{ github.event_name != 'pull_request' }}
+          # create local image (for scanning) if it is a pull request
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ needs.prep.outputs.tagged_images }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          # Note the mode=max here
+          # More: https://github.com/moby/buildkit#--export-cache-options
+          # And: https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          build-args: |
+            HOSTNAME=172.17.0.1
+            GEM_OAUTH_TOKEN=${{ secrets.gem_oauth_token }}
+            COMMIT_SHA=${{ needs.prep.outputs.commit_sha }}
+            BRANCH=${{ needs.prep.outputs.branch }}
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+#  notify-slack:
+#    if: github.event_name != 'pull_request'
+#    needs: [prep, build-and-upload-image]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Post to a Slack channel
+#        id: slack
+#        uses: slackapi/slack-github-action@v1.16.0
+#        with:
+#          channel-id: "docker-images-${{ needs.prep.outputs.repository_name }}"
+#          slack-message: "New image pushed: ${{ needs.prep.outputs.tagged_image }} built from <https://github.com/health-connector/${{ needs.prep.outputs.repository_name }}/commit/${{ needs.prep.outputs.commit_sha }}|${{ needs.prep.outputs.commit_sha }}> on `${{ needs.prep.outputs.branch }}`"
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.YELLR_BOT_TOKEN }}

--- a/.github/workflows/build-update-image.yml
+++ b/.github/workflows/build-update-image.yml
@@ -3,6 +3,7 @@ name: Build Update Image
 run-name: Build Update Image 
 
 on:
+  push: #temp to register workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/tag-latest-prod-image.yml
+++ b/.github/workflows/tag-latest-prod-image.yml
@@ -1,6 +1,7 @@
 name: Tag latest prod image
 
 on:
+  push: #temp to register workflow
   repository_dispatch:
     types:
       - tag-latest-prod-image

--- a/.github/workflows/tag-latest-prod-image.yml
+++ b/.github/workflows/tag-latest-prod-image.yml
@@ -1,0 +1,82 @@
+name: Tag latest prod image
+
+on:
+  repository_dispatch:
+    types:
+      - tag-latest-prod-image
+
+concurrency:
+  group: tag-latest-prod-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      repo: ${{ steps.prep.outputs.repo }}
+      image_tag: ${{ steps.prep.outputs.image_tag }}
+      registry_ghcr: ${{ steps.prep.outputs.registry_ghcr }}
+      short_sha: ${{ steps.prep.outputs.short_sha}}
+      branch: ${{ steps.prep.outputs.branch }}
+      latest_prod_tag: ${{ steps.prep.outputs.latest_prod_tag }}
+    steps:
+      - name: Git branch name
+        id: git-branch-name
+        uses: EthanSK/git-branch-name-action@v1
+      - name: Prepare info
+        id: prep
+        run: |
+          repo=health-connector/gluedb
+          image_tag=${{ github.event.client_payload.image }}
+          echo ::set-output name=repo::${repo}
+          echo ::set-output name=image_tag::${image_tag}
+          echo ::set-output name=registry_ghcr::ghcr.io
+          echo ::set-output name=short_sha::${{ github.event.client_payload.commit_sha }}
+          echo ::set-output name=branch::${{ github.event.client_payload.branch }}
+          echo ::set-output name=latest_prod_tag::latest-prod-${{ github.event.client_payload.client }}
+
+  build-and-upload-image:
+    runs-on: ubuntu-latest
+    needs: [prep]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prep.outputs.branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          # Key is named differently to avoid collision
+          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-multi-buildx
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ needs.prep.outputs.registry_ghcr }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag GHCR images
+        uses: shrink/actions-docker-registry-tag@v3
+        with:
+          registry:  ${{ needs.prep.outputs.registry_ghcr }}
+          repository: ${{ needs.prep.outputs.repo }}
+          target: ${{ needs.prep.outputs.image_tag }}
+          tags: ${{ needs.prep.outputs.latest_prod_tag }}
+
+#      - name: Pull, Tag, and Push Image 
+#        run: |
+#          docker pull ${{ needs.prep.outputs.registry_ecr }}/${{ needs.prep.outputs.image_tag }} 
+#          docker tag ${{ needs.prep.outputs.registry_ecr }}/${{ needs.prep.outputs.image_tag }} ${{ needs.prep.outputs.registry_ecr }}/${{ needs.prep.outputs.latest_prod_tag }}  
+#          docker push ${{ needs.prep.outputs.registry_ecr }}/${{ needs.prep.outputs.latest_prod_tag }}
+#          docker tag ${{ needs.prep.outputs.registry_ecr }}/${{ needs.prep.outputs.image_tag }} ${{ needs.prep.outputs.registry_ghcr }}/${{ needs.prep.outputs.latest_prod_tag }}
+#          docker push ${{ needs.prep.outputs.registry_ghcr }}/${{ needs.prep.outputs.latest_prod_tag }}
+

--- a/.github/workflows/tag-latest-prod-image.yml
+++ b/.github/workflows/tag-latest-prod-image.yml
@@ -1,7 +1,6 @@
 name: Tag latest prod image
 
 on:
-  push: #temp to register workflow
   repository_dispatch:
     types:
       - tag-latest-prod-image


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2663780/stories/188431437#
https://www.pivotaltracker.com/n/projects/2663780/stories/188565468
https://www.pivotaltracker.com/n/projects/2663780/stories/188565480

Adds reports, update, and 'tag-latest' workflows, which use targets in the main dockerfile from https://github.com/health-connector/gluedb/pull/171. Until that's merged, may be easier to see changes here via https://github.com/health-connector/gluedb/compare/188414578-dockerfile...health-connector:gluedb:add-additional-gha-workflows